### PR TITLE
Deal with non overlap more gracefully

### DIFF
--- a/bin/dist.py
+++ b/bin/dist.py
@@ -30,6 +30,12 @@ def main():
         default=False,
         help="compute bivariate distance metrics",
     )
+    parser.add_argument(
+        "--no-overlap",
+        action="store_false",
+        default=True,
+        help="Throw error if we're assessing two columns that have no overlap - i.e. are never observed together.",
+    )
 
     args = parser.parse_args()
 
@@ -38,7 +44,10 @@ def main():
 
     if args.bivariate:
         result = bivariate_distances_in_data(
-            df_a, df_b, distance_metric=args.main_metric
+            df_a,
+            df_b,
+            distance_metric=args.main_metric,
+            overlap_required=args.no_overlap,
         )
     else:
         result = univariate_distances_in_data(

--- a/src/counting.py
+++ b/src/counting.py
@@ -45,7 +45,7 @@ def normalize_count(column):
     return {k: v / len(column) for k, v in pl.Series(column).value_counts().rows()}
 
 
-def normalize_count_bivariate(column_1, column_2):
+def normalize_count_bivariate(column_1, column_2, overlap_required=True):
     """
     Count occurences of events between two categorical columns.
     This works on Polars'columns i.e. Polars Series.
@@ -53,6 +53,8 @@ def normalize_count_bivariate(column_1, column_2):
     Parameters:
     - column_1 (List or Polars Series):  A column in a dataframe.
     - column_2 (List or Polars Series):  Another column in a dataframe.
+    - overlap_required bool:  If the two columns don't have non-null overlap,
+                              throw error
 
     Returns:
     - dict: A Python dictionary, where keys are typles of categories from the
@@ -73,7 +75,8 @@ def normalize_count_bivariate(column_1, column_2):
     column_values = [
         vals for vals in zip(column_1, column_2) if not _is_none_or_nan_bivariate(vals)
     ]
-    assert len(column_values) > 0, "no overlap"
+    if overlap_required:
+        assert len(column_values) > 0, "no overlap"
     counter = Counter(column_values)
     # Note that Polars doesn't like to count tuples.
     return {k: v / len(column_values) for k, v in dict(counter).items()}

--- a/tests/test_distances.py
+++ b/tests/test_distances.py
@@ -141,6 +141,45 @@ def test_bivariate_distance_spot():
     )
 
 
+def test_bivariate_distance_no_overlap_exception():
+    with pytest.raises(AssertionError) as exc_info:
+        bivariate_distance(
+            pl.Series("foo", ["a", "a", None, None]),
+            pl.Series("bar", [None, None, "y", "y"]),
+            pl.Series("foo", ["a", "a", "a", "b"]),
+            pl.Series("bar", ["x", "x", "x", "y"]),
+            distance_metric="tvd",
+        )
+    assert exc_info.type == AssertionError
+
+
+def test_bivariate_distance_no_overlap_no_exception():
+    assert (
+        bivariate_distance(
+            pl.Series("foo", ["a", "a", None, None]),
+            pl.Series("bar", [None, None, "y", "y"]),
+            pl.Series("foo", ["a", "a", "a", "b"]),
+            pl.Series("bar", ["x", "x", "x", "y"]),
+            distance_metric="tvd",
+            overlap_required=False,
+        )
+        == None
+    )
+
+
+def test_bivariate_distance_no_overlap_spot():
+    assert (
+        bivariate_distance(
+            pl.Series("foo", ["a", "a", "b", "b"]),
+            pl.Series("bar", ["x", "x", "y", "y"]),
+            pl.Series("foo", ["a", "a", "a", "b"]),
+            pl.Series("bar", ["x", "x", "x", "y"]),
+            distance_metric="tvd",
+            overlap_required=False,
+        )
+        == 0.25
+    )
+
 @pytest.mark.parametrize("distance_metric", ["tvd", "kl", "js"])
 def test_bivariate_distances_in_data_smoke(distance_metric):
     df = pl.DataFrame(


### PR DESCRIPTION

## What does this do?

Assessing fidelity for pairs of columns only really makes sense if the pairs overlap in the reference data. For example, in the following, we don't know what the distance between `pair_1` and `pair_2` should be because we don't actually observe the two columns `foo` and `bar` together in the first data frame.
```python
# Pair from the first data frame
pair_1 = (pl.Series("foo", ["a", "a", None, None]),
          pl.Series("bar", [None, None, "y", "y"]),)
# Pair from the second data frame
pair_2 = (pl.Series("foo", ["a", "a", "a", "b"]),
          pl.Series("bar", ["x", "x", "x", "y"]),)
```
By default, this throws an error - arguably the safest behavior. 

This PR allows users to change this default behavior; returning `None` instead for a comparison that fits that pattern.

## Why do we want this?

Empirically we found that sometimes, this should not throw an error.

However, in some cases, this is true for large sparse data matrices like we currently use them to train LPMs.

## How was this tested?

The second commit in this PR adds tests.
